### PR TITLE
[Bug Fix] : Removed `ray()` debugging from `MoneyInput` setUp

### DIFF
--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -32,7 +32,6 @@ class MoneyInput extends TextInput
 
         $this->afterStateHydrated(static function (MoneyInput $component, $state): string {
 
-            ray($component->locale, $component->currency, $state)->green();
             $currencies = new ISOCurrencies();
             $numberFormatter = new NumberFormatter($component->locale, NumberFormatter::CURRENCY);
             $moneyFormatter = new IntlMoneyFormatter($numberFormatter, $currencies);


### PR DESCRIPTION
Description: The MoneyInput setUp function has a `ray()` method that comes from spatie/ray package, and is used to debug.

This throws an error 
`Call to undefined function Pelmered\FilamentMoneyField\Forms\Components\ray()`, 
when the consuming application is not using ray (screenshot below).

![image](https://github.com/pelmered/filament-money-field/assets/50393320/721aa452-d919-4b06-b979-47a7e6d5ce09)


**P.S:** Also, @pelmered:  on the filament package page, the form field usage is shown wrong, you'd have to correct that manually I guess (screenshot below). 

![image](https://github.com/pelmered/filament-money-field/assets/50393320/3386d551-80e1-4700-bdac-45831f854e9d)
