### PR TITLE
Fix to MoneyInput

### DIFF
--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -15,16 +15,12 @@ class MoneyInput extends TextInput
     {
         parent::setUp();
 
-        $this->inputMode('decimal');
-        $this->step(0.01);
-        $this->minValue = 0;
-
         $this->formatStateUsing(function (MoneyInput $component, $state): ?string {
             
-            $currency = $component->getCurrency()->getCode();
-            $state = MoneyFormatter::parseDecimal($state, $currency, $component->getLocale());
-          
             $this->prepare($component);
+
+            $currency = $component->getCurrency();
+            $locale = $component->getLocale();
 
             if (is_null($state)) {
                 return '';
@@ -33,15 +29,15 @@ class MoneyInput extends TextInput
                 return $state;
             }
 
-            return MoneyFormatter::decimalToMoneyString($state / 100, $component->getLocale());
+            return MoneyFormatter::format($state, $currency, $locale);
         });
 
         $this->dehydrateStateUsing(function (MoneyInput $component, $state): string {
 
-            $this->prepare($component);
-
             $currency = $component->getCurrency()->getCode();
             $state = MoneyFormatter::parseDecimal($state, $currency, $component->getLocale());
+
+            $this->prepare($component);
 
             return $state;
         });
@@ -50,15 +46,9 @@ class MoneyInput extends TextInput
     protected function prepare(MoneyInput $component): void
     {
         $formattingRules = MoneyFormatter::getFormattingRules($component->getLocale());
-
         $this->prefix($formattingRules->currencySymbol);
-
         if (config('filament-money-field.use_input_mask')) {
             $this->mask(RawJs::make('$money($input, \'' . $formattingRules->decimalSeparator . '\', \'' . $formattingRules->groupingSeparator . '\', ' . $formattingRules->fractionDigits . ')'));
         }
-
-        $this->stripCharacters($formattingRules->groupingSeparator);
-        // OR
-        $this->stripCharacters([',', '.', ' ',]);
     }
 }

--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -29,7 +29,7 @@ class MoneyInput extends TextInput
                 return $state;
             }
 
-            return MoneyFormatter::format($state, $currency, $locale);
+            return MoneyFormatter::formatAsDecimal($state, $currency, $locale);
         });
 
         $this->dehydrateStateUsing(function (MoneyInput $component, $state): string {

--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -47,8 +47,49 @@ class MoneyInput extends TextInput
     {
         $formattingRules = MoneyFormatter::getFormattingRules($component->getLocale());
         $this->prefix($formattingRules->currencySymbol);
+
         if (config('filament-money-field.use_input_mask')) {
             $this->mask(RawJs::make('$money($input, \'' . $formattingRules->decimalSeparator . '\', \'' . $formattingRules->groupingSeparator . '\', ' . $formattingRules->fractionDigits . ')'));
         }
+    }
+
+    public function minValue(mixed $min): static
+    {
+        $this->rule(static function (MoneyInput $component, mixed $state) use ($min) {
+            return function (string $attribute, mixed $value, \Closure $fail) use ($component, $state, $min) {
+
+                $value = MoneyFormatter::parseDecimal(
+                    $state, 
+                    $component->getCurrency()->getCode(),
+                    $component->getLocale()
+                );
+
+                if ($value < $min) {
+                    $fail('The :attribute must be greater than or equal to ' . $min . '.');
+                }
+            };
+        });
+
+        return $this;
+    }
+
+    public function maxValue(mixed $max): static
+    {
+        $this->rule(static function (MoneyInput $component, mixed $state) use ($max) {
+            return function (string $attribute, mixed $value, \Closure $fail) use ($component, $state, $max) {
+
+                $value = MoneyFormatter::parseDecimal(
+                    $state, 
+                    $component->getCurrency()->getCode(),
+                    $component->getLocale()
+                );
+
+                if ($value > $max) {
+                    $fail('The :attribute must be less than or equal to ' . $max . '.');
+                }
+            };
+        });
+
+        return $this;
     }
 }

--- a/src/MoneyFormatter.php
+++ b/src/MoneyFormatter.php
@@ -24,6 +24,19 @@ class MoneyFormatter
         return $moneyFormatter->format($money);
     }
 
+    public static function formatAsDecimal($value, $currency, $locale): string
+    {
+        if (is_null($value) || $value === '') {
+            return '';
+        }
+
+        $numberFormatter = self::getNumberFormatter($locale, \NumberFormatter::DECIMAL);
+        $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());
+
+        $money = new Money($value, $currency);
+        return $moneyFormatter->format($money); // outputs 1.000,00
+    }
+
     public static function parseDecimal($moneyString, $currency, $locale): string
     {
         if (is_null($moneyString) || $moneyString === '') {

--- a/tests/MoneyFormatterTest.php
+++ b/tests/MoneyFormatterTest.php
@@ -3,8 +3,10 @@
 namespace Pelmered\FilamentMoneyField\Tests;
 use Money\Currency;
 use Pelmered\FilamentMoneyField\MoneyFormatter;
-use PHPUnit\Framework;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversClass(MoneyFormatter::class)]
 final class MoneyFormatterTest extends TestCase
 {
     public static function provideMoneyDataSEK(): array
@@ -33,6 +35,32 @@ final class MoneyFormatterTest extends TestCase
         ];
     }
 
+    public static function provideDecimalMoneyDataSEK(): array
+    {
+        return [
+            'thousands' => [
+                1000000,
+                '10 000,00',
+            ],
+            'decimals' => [
+                10045,
+                '100,45',
+            ],
+            'millions' => [
+                123456789,
+                '1 234 567,89',
+            ],
+            'empty_string' => [
+                '',
+                '',
+            ],
+            'null' => [
+                null,
+                '',
+            ],
+        ];
+    }
+
     public static function provideMoneyDataUSD(): array
     {
         return [
@@ -47,6 +75,32 @@ final class MoneyFormatterTest extends TestCase
             'millions' => [
                 123456789,
                 '$1,234,567.89',
+            ],
+            'empty_string' => [
+                '',
+                '',
+            ],
+            'null' => [
+                null,
+                '',
+            ],
+        ];
+    }
+
+    public static function provideDecimalMoneyDataUSD(): array
+    {
+        return [
+            'thousands' => [
+                1000000,
+                '10,000.00',
+            ],
+            'decimals' => [
+                10045,
+                '100.45',
+            ],
+            'millions' => [
+                123456789,
+                '1,234,567.89',
             ],
             'empty_string' => [
                 '',
@@ -110,26 +164,8 @@ final class MoneyFormatterTest extends TestCase
             ],
         ];
     }
-
-
-    /**
-     * @covers MoneyFormatter::format
-     * @dataProvider provideMoneyDataSEK
-     */
-    #[Framework\CoversClass(MoneyFormatter::class)]
-    public function testMoneyFormatterSEK(mixed $input, string $expectedOutput)
-    {
-        self::assertSame(
-            static::replaceNonBreakingSpaces($expectedOutput),
-            MoneyFormatter::format($input, new Currency('SEK'), 'sv_SE')
-        );
-    }
-
-    /**
-     * @covers MoneyFormatter::format
-     * @dataProvider provideMoneyDataUSD
-     */
-    #[Framework\CoversClass(MoneyFormatter::class)]
+    
+    #[DataProvider('provideMoneyDataUSD')]
     public function testMoneyFormatterUSD(mixed $input, string $expectedOutput)
     {
         self::assertSame(
@@ -138,11 +174,37 @@ final class MoneyFormatterTest extends TestCase
         );
     }
 
-    /**
-     * @covers MoneyFormatter::parseDecimal
-     * @dataProvider provideDecimalDataSEK
-     */
-    #[Framework\CoversClass(MoneyFormatter::class)]
+    #[DataProvider('provideMoneyDataSEK')]
+    public function testMoneyFormatterSEK(mixed $input, string $expectedOutput)
+    {
+        self::assertSame(
+            static::replaceNonBreakingSpaces($expectedOutput),
+            MoneyFormatter::format($input, new Currency('SEK'), 'sv_SE')
+        );
+    }
+
+    #[DataProvider('provideDecimalMoneyDataUSD')]
+    //#[CoversClass(MoneyFormatter::class)]
+    public function testMoneyDecimalFormatterUSD(mixed $input, string $expectedOutput)
+    {
+        self::assertSame(
+            static::replaceNonBreakingSpaces($expectedOutput),
+            MoneyFormatter::formatAsDecimal($input, new Currency('USD'), 'en_US')
+        );
+    }
+
+    #[DataProvider('provideDecimalMoneyDataSEK')]
+    //#[CoversClass(MoneyFormatter::class)]
+    public function testMoneyDecimalFormatterSEK(mixed $input, string $expectedOutput)
+    {
+        self::assertSame(
+            static::replaceNonBreakingSpaces($expectedOutput),
+            MoneyFormatter::formatAsDecimal($input, new Currency('SEK'), 'sv_SE')
+        );
+    }
+    
+    #[DataProvider('provideDecimalDataSEK')]
+    //#[CoversClass(MoneyFormatter::class)]
     public function testMoneyParserDecimalSEK(mixed $input, string $expectedOutput)
     {
         self::assertSame(
@@ -151,11 +213,7 @@ final class MoneyFormatterTest extends TestCase
         );
     }
 
-    /**
-     * @covers MoneyFormatter::parseDecimal
-     * @dataProvider provideDecimalDataUSD
-     */
-    #[Framework\CoversClass(MoneyFormatter::class)]
+    #[DataProvider('provideDecimalDataUSD')]
     public function testMoneyParserDecimalUSD(mixed $input, string $expectedOutput)
     {
         self::assertSame(


### PR DESCRIPTION
First, thanks for making this plugin. The native handling for money in Filament is lacking! Maybe this plugin will be pulled into Filament core one day? :smile: 

I was having a similar issue to #9. As stated in the requirements for this plugin, I am storing my money as an integer value of minor units, and the MoneyColumn looked great, but the MoneyInput was not showing the decimal value correctly, even with the mask. For example, the integer value 400023 was becoming 400,023 instead of 4000.23.

So on the input field hydration, essentially copied what you did for MoneyColumn. However I also created a new static method on the MoneyFormatter to output the intl. decimal format instead (i.e. without the currency symbol), so it will work with and without the mask applied. I added some tests for this new method. Oh, and in the tests, I changed the metadata in the comments to attributes to avoid deprecation notices (apparently [support for metadata in the comments will be removed in PHPUnit 12](https://github.com/sebastianbergmann/phpunit/issues/4506)).

Also, I added minValue and maxValue overrides that use the MoneyFormatter to parse the decimal input before comparing with the passed-in max and min values. The base minValue and maxValue methods that are built-in to numeric inputs in Filament were not working because validation seems to occur _before_ dehydration, where the input gets parsed.

I tested the MoneyInput with GBP, USD, and SEK, with and without the mask, and it seemed to work well. Please let me know if I've missed something, and feel free to make edits if needed.