### PR TITLE
defer configuration using closure

### DIFF
--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -50,7 +50,7 @@ class MoneyInput extends TextInput
     {
         $symbolPlacement = Config::get('filament-money-field.form_currency_symbol_placement', 'before');
 
-        $getCurrencySymbol = function ($component) {
+        $getCurrencySymbol = function (MoneyInput $component) {
             $formattingRules = MoneyFormatter::getFormattingRules($component->getLocale());
             return $formattingRules->currencySymbol;
         };
@@ -62,7 +62,7 @@ class MoneyInput extends TextInput
         }
 
         if (config('filament-money-field.use_input_mask')) {
-            $this->mask(function ($component) {
+            $this->mask(function (MoneyInput $component) {
                 $formattingRules = MoneyFormatter::getFormattingRules($component->getLocale());
                 return RawJs::make('$money($input, \'' . $formattingRules->decimalSeparator . '\', \'' . $formattingRules->groupingSeparator . '\', ' . $formattingRules->fractionDigits . ')');
             });


### PR DESCRIPTION
This PR fixes Issue https://github.com/pelmered/filament-money-field/issues/21

It defers the configuration of affixes and mask using a closure. Not all information is present when setUp() is called, especially in live() mode. Using a closure the retrieval of the information is defered to the "get" methods and works as expected.