### PR TITLE
Added fix for empty stings in a query (pelmered/filament-money-field#18)

### DIFF
--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -35,13 +35,14 @@ class MoneyInput extends TextInput
             return MoneyFormatter::formatAsDecimal($state, $currency, $locale);
         });
 
-        $this->dehydrateStateUsing(function (MoneyInput $component, $state): string {
-
+        $this->dehydrateStateUsing(function (MoneyInput $component, $state): ?string {
             $currency = $component->getCurrency();
             $state = MoneyFormatter::parseDecimal($state, $currency, $component->getLocale());
 
-            $this->prepare();
-
+            if (empty($state)) {
+                return null;
+            }
+            
             return $state;
         });
     }


### PR DESCRIPTION
When the state is empty return null instead of a empty string.
When returning a empty string the query will be like this:

```
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `laravel_2`.`products`.`price_discount` at row 1

update `products` SET `price_discount` = , `stock_tracking` = 0, `products`.`updated_at` = 2024-04-23 08:56:08 WHERE `id` = 2
```

After this fix it checks for empty strings and returns null instead so it gets filtered out of the query.