### PR TITLE
Fix min comparison check in MinValueRule.php

### DIFF
--- a/src/Forms/Rules/MinValueRule.php
+++ b/src/Forms/Rules/MinValueRule.php
@@ -26,7 +26,7 @@ readonly class MinValueRule implements ValidationRule
                 $locale
             );
 
-            if ($minorValue <= $this->min) {
+            if ($minorValue < $this->min) {
                 $fail(
                     strtr(
                         'The {attribute} must be at least {value}.',


### PR DESCRIPTION
Fix the comparison check as currently if the `->minValue(25)` is set - entering the value 25 fails validation