### PR TITLE
fix: Make sur to use parent getLabel() to make use of translateLabel()

### DIFF
--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -118,11 +118,14 @@ class MoneyInput extends TextInput
             return $this->label->toHtml();
         }
 
-        return $this->evaluate($this->label)
-               ?? (string) str($this->getName())
-                   ->afterLast('.')
-                   ->kebab()
-                   ->replace(['-', '_'], ' ')
-                   ->title();
+        if ($label = parent::getLabel()) {
+            return $label;
+        }
+
+        return (string) str($this->getName())
+            ->afterLast('.')
+            ->kebab()
+            ->replace(['-', '_'], ' ')
+            ->title();
     }
 }


### PR DESCRIPTION
Because the package overrides `getLabel()` method, the usage of `$component->translateLabel()` is not respected. 

By calling the parent method, we are making sure the label will get translated if configured to.