### PR TITLE
Fix Closures in MaxValue and MinValue

### DIFF
--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -7,13 +7,23 @@ use Filament\Support\RawJs;
 use Pelmered\FilamentMoneyField\Concerns\HasMoneyAttributes;
 use Pelmered\FilamentMoneyField\Forms\Rules\MaxValueRule;
 use Pelmered\FilamentMoneyField\Forms\Rules\MinValueRule;
-use Pelmered\FilamentMoneyField\MoneyFormatter\MoneyFormatter;
+use Pelmered\FilamentMoneyField\MoneyFormatter;
 
 class MoneyInput extends TextInput
 {
     use HasMoneyAttributes;
 
     protected ?string $symbolPlacement = null;
+
+    /**
+     * @var scalar | Closure | null
+     */
+    protected $maxValue = null;
+
+    /**
+     * @var scalar | Closure | null
+     */
+    protected $minValue = null;
 
     protected function setUp(): void
     {
@@ -99,14 +109,30 @@ class MoneyInput extends TextInput
 
     public function minValue(mixed $value): static
     {
-        $this->rule(new MinValueRule((int) $this->evaluate($value), $this));
+        $this->minValue = $value;
+
+        $this->rule(
+            static function (MoneyInput $component) {
+                $value = $component->getMinValue();
+                return new MinValueRule($value, $component);
+            },
+            static fn (MoneyInput $component): bool => filled($component->getMinValue())
+        );
 
         return $this;
     }
 
     public function maxValue(mixed $value): static
     {
-        $this->rule(new MaxValueRule((int) $this->evaluate($value), $this));
+        $this->maxValue = $value;
+
+        $this->rule(
+            static function (MoneyInput $component) {
+                $value = $component->getMaxValue();
+                return new MaxValueRule($value, $component);
+            },
+            static fn (MoneyInput $component): bool => filled($component->getMaxValue())
+        );
 
         return $this;
     }

--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -7,7 +7,7 @@ use Filament\Support\RawJs;
 use Pelmered\FilamentMoneyField\Concerns\HasMoneyAttributes;
 use Pelmered\FilamentMoneyField\Forms\Rules\MaxValueRule;
 use Pelmered\FilamentMoneyField\Forms\Rules\MinValueRule;
-use Pelmered\FilamentMoneyField\MoneyFormatter;
+use Pelmered\FilamentMoneyField\MoneyFormatter\MoneyFormatter;
 
 class MoneyInput extends TextInput
 {

--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -8,6 +8,7 @@ use Pelmered\FilamentMoneyField\Concerns\HasMoneyAttributes;
 use Pelmered\FilamentMoneyField\Forms\Rules\MaxValueRule;
 use Pelmered\FilamentMoneyField\Forms\Rules\MinValueRule;
 use Pelmered\FilamentMoneyField\MoneyFormatter\MoneyFormatter;
+use Closure;
 
 class MoneyInput extends TextInput
 {


### PR DESCRIPTION
I encountered issues similar to #72 when trying to inject a service into a closure passed to the `minValue` method.  

I compared the `MoneyInput::minValue` method with its counterpart in [TextInput::getMinValue](https://github.com/filamentphp/filament/blob/862fa4397ec13daf9b655474d5c1a20abac25433/packages/forms/src/Components/TextInput.php#L110) and noticed that `$this->evaluate($value)` was being called too early in the `MoneyInput` implementation.  

This was what caused the `Typed property Filament\Forms\Components\Component::$container must not be accessed before initialization` Error.

As the closure is evaluated in [TextInput::getMinValue](https://github.com/filamentphp/filament/blob/862fa4397ec13daf9b655474d5c1a20abac25433/packages/forms/src/Components/TextInput.php#L209) anyway, there seems to be no need for `minValue` or `maxValue` to evaluate $value at all.

So i aligned the way `minValue` and `maxValue` works to the way `TextInput` does it.

After these changes:
- Closures that depend on Laravel's dependency injection or Filament's closure injection features work correctly.  
- Passing integers values remains fully functional.
- Issue #72 is very likely resolved