### PR TITLE
MaxValue Rule should only fail, when $value is higher than the given maximal value

### DIFF
--- a/src/Forms/Rules/MaxValueRule.php
+++ b/src/Forms/Rules/MaxValueRule.php
@@ -27,7 +27,7 @@ readonly class MaxValueRule implements ValidationRule
                 $locale
             );
 
-            if ($minorValue >= $this->max) {
+            if ($minorValue > $this->max) {
                 $fail(
                     strtr(
                         'The {attribute} must be less than or equal to {value}.',


### PR DESCRIPTION
### Description of the Issue  

The failure message in the `MaxValueRule` currently states:  
`The {attribute} must be less than or equal to {value}`  

However, the corresponding `if` condition in the implementation looks like this:  

```php  
if ($minorValue >= $this->max) {  
    // fail  
}  
```  

This causes the maximum value itself to be incorrectly treated as invalid.  

### Example  

- **Configured max value:** `10`  
- **Input value:** `10`  

Expected outcome: The validation should pass, as the input meets the "less than or equal to" condition.  
Actual outcome: The validation fails with the error message:  
`The reduction must be less than or equal to 10`  

### Proposed Fix  

The issue lies in the use of the `>=` operator in the condition. To align the behavior with the intended rule, the check should verify only if the value is strictly greater than the maximum:  

```php  
if ($minorValue > $this->max) {  
    // fail  
}  
```  

This ensures that the maximum value is accepted as valid, consistent with the rule's message.  
