### PR TITLE
2.0 column null in model

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Don't forget to run your migrations.
 Each money column should have a cast that casts the column to a Money object and the currency column should have a cast that casts the column to a Currency object
 
 ```php
-use Pelmered\FilamentMoneyField\Casts\CurrencyCast;
-use Pelmered\FilamentMoneyField\Casts\MoneyCast;
+use Pelmered\Larapara\Casts\CurrencyCast;
+use Pelmered\Larapara\Casts\MoneyCast;
 
 protected function casts(): array
 {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,8 +8,8 @@ _-As of now, this is required, will be made optional in the future.-_
 Each money column should have a cast that casts the column to a Money object and the currency column should have a cast that casts the column to a Currency object
 
 ```php
-use Pelmered\FilamentMoneyField\Casts\CurrencyCast;
-use Pelmered\FilamentMoneyField\Casts\MoneyCast;
+use Pelmered\Larapara\Casts\CurrencyCast;
+use Pelmered\Larapara\Casts\MoneyCast;
 
 protected function casts(): array
 {

--- a/src/Concerns/HasMoneyAttributes.php
+++ b/src/Concerns/HasMoneyAttributes.php
@@ -27,7 +27,10 @@ trait HasMoneyAttributes
         }
 
         if ($this->getRecord()) {
-            return Currency::fromCode($this->getRecord()->{$this->getCurrencyColumn()});
+            $currencyCode = $this->getRecord()->{$this->getCurrencyColumn()};
+            if ($currencyCode) {
+                return Currency::fromCode($currencyCode);
+            }
         }
 
         return MoneyFormatter::getDefaultCurrency();

--- a/tests/Support/Models/Post.php
+++ b/tests/Support/Models/Post.php
@@ -5,8 +5,8 @@ namespace Pelmered\FilamentMoneyField\Tests\Support\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Pelmered\FilamentMoneyField\Casts\CurrencyCast;
-use Pelmered\FilamentMoneyField\Casts\MoneyCast;
+use Pelmered\LaraPara\Casts\CurrencyCast;
+use Pelmered\LaraPara\Casts\MoneyCast;
 use Pelmered\FilamentMoneyField\Tests\Support\Database\Factories\PostFactory;
 
 class Post extends Model

--- a/tests/Support/Models/Post.php
+++ b/tests/Support/Models/Post.php
@@ -5,9 +5,9 @@ namespace Pelmered\FilamentMoneyField\Tests\Support\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Pelmered\FilamentMoneyField\Tests\Support\Database\Factories\PostFactory;
 use Pelmered\LaraPara\Casts\CurrencyCast;
 use Pelmered\LaraPara\Casts\MoneyCast;
-use Pelmered\FilamentMoneyField\Tests\Support\Database\Factories\PostFactory;
 
 class Post extends Model
 {


### PR DESCRIPTION
I found this error: When using a MoneyInput, if the field value is null, I get an error.
Unfortunately, this is a part not covered by the tests, in fact, the `tests/Support/Models/Post.php` class is never instantiated in the tests (which is why didn't get the wrong namespaces error I fixed).
