### PR TITLE
Filament v4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "pelmered/larapara": "dev-main"
     },
     "require-dev": {
-        "filament/filament": "^3.2",
+        "filament/filament": "^4.0",
         "orchestra/testbench": "^9.0",
         "nunomaduro/collision": "^8.0",
         "laravel/pint": "^1.16",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^8.2",
         "ext-intl": "*",
-        "filament/support": "^v3.2.39",
+        "filament/support": "^v4.0.0",
         "moneyphp/money": "^4.0",
         "illuminate/support": "^11.24 | ^12",
         "php-static-analysis/attributes": "^0.3.1 | ^0.4.0",

--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -2,7 +2,7 @@
 
 namespace Pelmered\FilamentMoneyField\Forms\Components;
 
-use Filament\Forms\Components\Actions\Action;
+use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;

--- a/tests/Components/FormInputEdgeCasesTest.php
+++ b/tests/Components/FormInputEdgeCasesTest.php
@@ -1,17 +1,18 @@
 <?php
 
 use Filament\Forms\ComponentContainer;
-use Filament\Forms\Get;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
 use Money\Currency;
 use Money\Money;
 use Pelmered\FilamentMoneyField\Forms\Components\MoneyInput;
 use Pelmered\FilamentMoneyField\Tests\Support\Components\TestComponent;
 
 it('handles empty string properly', function (): void {
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('money')])
-        ->getComponent('data.money');
+        ->getComponent('money');
 
     // Using an empty string should result in a null value
     $moneyValue = $component->getState('');
@@ -23,7 +24,7 @@ it('handles extremely large amounts properly', function (): void {
     // Use actual Money object directly since filling with string isn't working
     $largeMoneyValue = new Money('999999999999', new Currency('USD'));
 
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('money')])
         ->fill(['money' => $largeMoneyValue]);
@@ -36,7 +37,7 @@ it('handles extremely large amounts properly', function (): void {
 
 it('handles currency changes gracefully', function (): void {
     // First test with USD currency
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('money')->currency('USD')])
         ->fill(['money' => new Money('12345', new Currency('USD'))]);
@@ -48,7 +49,7 @@ it('handles currency changes gracefully', function (): void {
     expect($state['money']->getCurrency()->getCode())->toBe('USD');
 
     // Create a new component with EUR currency but use the same Money object with USD
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('money')->currency('EUR')])
         ->fill(['money' => new Money('12345', new Currency('EUR'))]);
@@ -62,7 +63,7 @@ it('handles currency changes gracefully', function (): void {
 });
 
 it('handles negative values correctly', function (): void {
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('price')])
         ->fill(['price' => new Money('-50000', new Currency('USD'))]);
@@ -71,7 +72,7 @@ it('handles negative values correctly', function (): void {
 });
 
 it('handles zero values correctly', function (): void {
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('price')])
         ->fill(['price' => new Money('0', new Currency('USD'))]);
@@ -80,7 +81,7 @@ it('handles zero values correctly', function (): void {
 });
 
 it('handles empty string as null', function (): void {
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('price')])
         ->fill(['price' => '']);
@@ -89,20 +90,20 @@ it('handles empty string as null', function (): void {
 });
 
 it('handles custom step values', function (): void {
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([
             MoneyInput::make('price')->step(0.01),
         ])
         ->fill(['price' => new Money('10001', new Currency('USD'))]);
 
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
 
     expect($field->getStep())->toBe(0.01);
 });
 
 it('handles hidden state correctly', function (): void {
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([
             MoneyInput::make('price')
@@ -113,7 +114,7 @@ it('handles hidden state correctly', function (): void {
             'hide_price' => false,
         ]);
 
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
     expect($field->isHidden())->toBeFalse();
 
     $component->fill([
@@ -125,7 +126,7 @@ it('handles hidden state correctly', function (): void {
 });
 
 it('handles disabled state correctly', function (): void {
-    $component = ComponentContainer::make(TestComponent::make())
+    $component = Schema::make(TestComponent::make())
         ->statePath('data')
         ->components([
             MoneyInput::make('price')
@@ -136,7 +137,7 @@ it('handles disabled state correctly', function (): void {
             'disable_price' => false,
         ]);
 
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
     expect($field->isDisabled())->toBeFalse();
 
     $component->fill([

--- a/tests/Components/FormInputTest.php
+++ b/tests/Components/FormInputTest.php
@@ -1,13 +1,15 @@
 <?php
 
 use Filament\Forms\ComponentContainer;
-use Filament\Forms\Components\Actions\Action;
+
 use Illuminate\Validation\ValidationException;
 use Money\Currency;
 use Money\Money;
 use Pelmered\FilamentMoneyField\Forms\Components\MoneyInput;
 use Pelmered\FilamentMoneyField\Tests\Support\Components\FormTestComponent;
 use Pelmered\LaraPara\Exceptions\UnsupportedCurrency;
+use Filament\Schemas\Schema;
+use Filament\Actions\Action;
 
 it('accepts form input money in numeric format', function (): void {
     $component = createFormTestComponent(
@@ -15,7 +17,8 @@ it('accepts form input money in numeric format', function (): void {
         ['price' => new Money(12345600, new Currency('USD'))],
         'price',
     );
-    expect($component->getState()['price']->getAmount())->toEqual('12345600');
+
+    expect($component->getComponent('price')->getState())->toEqual('123,456.00');
 });
 
 it('accepts null state and returns null', function (): void {
@@ -42,7 +45,7 @@ it('sets currency symbol placement after with global config', function (): void 
         ['amount' => 20],
     );
     /** @var MoneyInput $field */
-    $field = $component->getComponent('data.amount');
+    $field = $component->getComponent('amount');
     expect($field->getSuffixLabel())->toEqual('$');
     expect($field->getPrefixLabel())->toBeNull();
 });
@@ -54,7 +57,7 @@ it('sets currency symbol placement before with global config', function (): void
         [MoneyInput::make('amount')],
         ['amount' => 20],
     );
-    $field = $component->getComponent('data.amount');
+    $field = $component->getComponent('amount');
     expect($field->getPrefixLabel())->toEqual('$');
     expect($field->getSuffixLabel())->toBeNull();
 });
@@ -66,7 +69,7 @@ it('hides currency symbol with global config', function (): void {
         [MoneyInput::make('amount')],
         ['amount' => 20],
     );
-    $field = $component->getComponent('data.amount');
+    $field = $component->getComponent('amount');
     expect($field->getPrefixLabel())->toBeNull();
     expect($field->getSuffixLabel())->toBeNull();
 });
@@ -77,7 +80,7 @@ it('sets currency symbol placement after with on field config', function (): voi
         ['amount' => 20],
     );
 
-    $field = $component->getComponent('data.amount');
+    $field = $component->getComponent('amount');
 
     expect($field->getSuffixLabel())->toEqual('$');
     expect($field->getPrefixLabel())->toBeNull();
@@ -89,25 +92,25 @@ it('sets currency symbol placement before with on field config', function (): vo
         ['amount' => 20],
     );
 
-    $field = $component->getComponent('data.amount');
+    $field = $component->getComponent('amount');
     expect($field->getPrefixLabel())->toEqual('$');
     expect($field->getSuffixLabel())->toBeNull();
 });
 
 it('hides currency symbol with on field config', function (): void {
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('amount')->symbolPlacement('hidden')])
         ->fill(['amount' => 20]);
 
-    $field = $component->getComponent('data.amount');
+    $field = $component->getComponent('amount');
     expect($field->getPrefixLabel())->toBeNull();
     expect($field->getSuffixLabel())->toBeNull();
 });
 
 it('throws exception when currency symbol placement in invalid on field', function (): void {
     expect(function (): void {
-        ComponentContainer::make(FormTestComponent::make())
+        Schema::make(FormTestComponent::make())
             ->statePath('data')
             ->components([MoneyInput::make('price')->symbolPlacement('invalid')])
             ->fill(['price' => 20]);
@@ -117,12 +120,12 @@ it('throws exception when currency symbol placement in invalid on field', functi
 it('makes input mask', function (): void {
     config(['filament-money-field.use_input_mask' => true]);
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('price')])
         ->fill(['price' => 20]);
 
-    expect($component->getComponent('data.price')->getMask()->toHtml())
+    expect($component->getComponent('price')->getMask()->toHtml())
         ->toContain('money($input');
 });
 
@@ -206,12 +209,12 @@ it('throws exception with unsupported currency', function (): void {
 it('allows label to be overrided', function (): void {
     $field = (new MoneyInput('price'))->label('Custom Label');
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([$field])
         ->fill([$field->getName() => 45345]);
 
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
     expect($field->getLabel())->toEqual('Custom Label');
 });
 
@@ -220,19 +223,19 @@ it('resolves label closures', function (): void {
         return 'Custom Label in Closure';
     });
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([$field])
         ->fill([$field->getName() => 45345]);
 
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
     expect($field->getLabel())->toEqual('Custom Label in Closure');
 });
 
 it('sets decimals on field', function (): void {
     // Test with decimals(1)
     $field     = (new MoneyInput('price'))->decimals(1);
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([$field])
         ->fill([$field->getName() => new Money(2345345, new Currency('USD'))]);
@@ -242,7 +245,7 @@ it('sets decimals on field', function (): void {
 
     // Test with decimals(3)
     $field     = (new MoneyInput('price'))->decimals(3);
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([$field])
         ->fill([$field->getName() => new Money(2345345, new Currency('USD'))]);
@@ -252,7 +255,7 @@ it('sets decimals on field', function (): void {
 
     // Test with negative decimals(-2)
     $field     = (new MoneyInput('price'))->decimals(-2);
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([$field])
         ->fill([$field->getName() => new Money(2345345, new Currency('USD'))]);
@@ -262,7 +265,7 @@ it('sets decimals on field', function (): void {
 });
 
 it('accepts form input money with money cast', function (): void {
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('price_cast')])
         ->fill(['price_cast' => new Money(12345600, new Currency('USD'))]);
@@ -274,7 +277,7 @@ it('allows setting a currency column', function (): void {
     // Set up currencies
     config(['filament-money-field.available_currencies' => ['USD', 'EUR', 'SEK']]);
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([
             MoneyInput::make('price')
@@ -290,13 +293,13 @@ it('allows setting a currency column', function (): void {
 it('allows can enable or disable currency switcher with global config', function (): void {
     config(['filament-money-field.currency_switcher_enabled_default' => false]);
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('price')])
         ->fill(['price' => new Money(123456, new Currency('EUR'))]);
 
     /** @var MoneyInput $field */
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
 
     expect($field)->toBeInstanceOf(MoneyInput::class);
 
@@ -304,13 +307,13 @@ it('allows can enable or disable currency switcher with global config', function
 
     config(['filament-money-field.currency_switcher_enabled_default' => true]);
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([MoneyInput::make('price')])
         ->fill(['price' => new Money(123456, new Currency('EUR'))]);
 
     /** @var MoneyInput $field */
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
 
     expect($field)->toBeInstanceOf(MoneyInput::class);
 
@@ -322,7 +325,7 @@ it('allows to override currency switcher with field config', function (): void {
     // Global config = false, field config = true => enabled
     config(['filament-money-field.currency_switcher_enabled_default' => false]);
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([
             MoneyInput::make('price')->currencySwitcherEnabled(),
@@ -330,7 +333,7 @@ it('allows to override currency switcher with field config', function (): void {
         ->fill(['price' => new Money(123456, new Currency('EUR'))]);
 
     /** @var MoneyInput $field */
-    $field  = $component->getComponent('data.price');
+    $field  = $component->getComponent('price');
     $action = $field->getSuffixActions()['changeCurrency'];
 
     expect($field)->toBeInstanceOf(MoneyInput::class);
@@ -339,7 +342,7 @@ it('allows to override currency switcher with field config', function (): void {
     // Global config = true, field config = false => disabled
     config(['filament-money-field.currency_switcher_enabled_default' => true]);
 
-    $component = ComponentContainer::make(FormTestComponent::make())
+    $component = Schema::make(FormTestComponent::make())
         ->statePath('data')
         ->components([
             MoneyInput::make('price')->currencySwitcherDisabled(),
@@ -347,7 +350,7 @@ it('allows to override currency switcher with field config', function (): void {
         ->fill(['price' => new Money(123456, new Currency('EUR'))]);
 
     /** @var MoneyInput $field */
-    $field = $component->getComponent('data.price');
+    $field = $component->getComponent('price');
 
     expect($field)->toBeInstanceOf(MoneyInput::class);
     expect($field->getSuffixActions())->toBeEmpty();

--- a/tests/Components/MoneyEntryTest.php
+++ b/tests/Components/MoneyEntryTest.php
@@ -1,31 +1,30 @@
 <?php
 
-use Filament\Infolists\ComponentContainer;
+use Money\Currency;
+use Money\Money;
 use Pelmered\FilamentMoneyField\Infolists\Components\MoneyEntry;
-use Pelmered\FilamentMoneyField\Tests\Support\Components\InfolistTestComponent;
+use Filament\Schemas\Schema;
 
 it('formats infolist money in usd', function (): void {
     $entry = MoneyEntry::make('price');
+    $state = new Money(100000000, new Currency('USD'));
 
-    $component = ComponentContainer::make(InfolistTestComponent::make())
-        ->components([$entry])
-        ->state([$entry->getName() => 100000000]);
+    $schema = Schema::make();
+    $entry->container($schema);
 
-    $entry = $component->getComponent('price');
+    $formatted = $entry->formatState($state);
 
-    expect($entry->formatState($entry->getState()))->toEqual('$1,000,000.00');
+    expect($formatted)->toEqual('$1,000,000.00');
 });
 
 it('formats infolist money in sek', function (): void {
     $entry = MoneyEntry::make('price')->currency('SEK')->locale('sv_SE');
+    $state = new Money(1000000, new Currency('SEK'));
 
-    $component = ComponentContainer::make(InfolistTestComponent::make())
-        ->components([$entry])
-        ->state([$entry->getName() => 1000000]);
+    $schema = Schema::make();
+    $entry->container($schema);
 
-    $entry = $component->getComponent('price');
-
-    $formatted = $entry->formatState($entry->getState());
+    $formatted = $entry->formatState($state);
     $expected  = '10 000,00 kr';
 
     expect(replaceNonBreakingSpaces($formatted))->toEqual(replaceNonBreakingSpaces($expected));
@@ -33,26 +32,24 @@ it('formats infolist money in sek', function (): void {
 
 it('formats infolist money in short format in USD', function (): void {
     $entry = MoneyEntry::make('price')->short();
+    $state = new Money(123456789, new Currency('USD'));
 
-    $component = ComponentContainer::make(InfolistTestComponent::make())
-        ->components([$entry])
-        ->state([$entry->getName() => 123456789]);
+    $schema = Schema::make();
+    $entry->container($schema);
 
-    $entry = $component->getComponent('price');
+    $formatted = $entry->formatState($state);
 
-    expect($entry->formatState($entry->getState()))->toEqual('$1.23M');
+    expect($formatted)->toEqual('$1.23M');
 });
 
 it('formats infolist money in short format in sek', function (): void {
     $entry = MoneyEntry::make('price')->short()->currency('SEK')->locale('sv_SE');
+    $state = new Money(123456, new Currency('SEK'));
 
-    $component = ComponentContainer::make(InfolistTestComponent::make())
-        ->components([$entry])
-        ->state([$entry->getName() => 123456]);
+    $schema = Schema::make();
+    $entry->container($schema);
 
-    $entry = $component->getComponent('price');
-
-    $formatted = $entry->formatState($entry->getState());
+    $formatted = $entry->formatState($state);
     $expected  = '1,23K kr';
 
     expect(replaceNonBreakingSpaces($formatted))->toEqual(replaceNonBreakingSpaces($expected));
@@ -60,14 +57,12 @@ it('formats infolist money in short format in sek', function (): void {
 
 it('formats infolist money in sek with no decimals', function (): void {
     $entry = MoneyEntry::make('price')->currency('SEK')->locale('sv_SE')->decimals(0);
+    $state = new Money(1000000, new Currency('SEK'));
 
-    $component = ComponentContainer::make(InfolistTestComponent::make())
-        ->components([$entry])
-        ->state([$entry->getName() => 1000000]);
+    $schema = Schema::make();
+    $entry->container($schema);
 
-    $entry = $component->getComponent('price');
-
-    $formatted = $entry->formatState($entry->getState());
+    $formatted = $entry->formatState($state);
     $expected  = '10 000 kr';
 
     expect(replaceNonBreakingSpaces($formatted))->toEqual(replaceNonBreakingSpaces($expected));

--- a/tests/Components/ValidationRulesTest.php
+++ b/tests/Components/ValidationRulesTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use Filament\Forms\ComponentContainer;
 use Illuminate\Support\Facades\Validator;
 use Pelmered\FilamentMoneyField\Forms\Components\MoneyInput;
 use Pelmered\FilamentMoneyField\Forms\Rules\MaxValueRule;
 use Pelmered\FilamentMoneyField\Forms\Rules\MinValueRule;
 use Pelmered\FilamentMoneyField\Tests\Support\Components\FormTestComponent;
+use Filament\Schemas\Components\Component;
 
 it('validates min value using MinValueRule', function (): void {
     // Create the input component for testing
@@ -13,15 +13,8 @@ it('validates min value using MinValueRule', function (): void {
         ->currency('USD')
         ->locale('en_US');
 
-    // Initialize the component
-    $container = ComponentContainer::make(FormTestComponent::make())
-        ->statePath('data')
-        ->components([$moneyInput]);
-
-    $fieldComponent = $container->getComponent('data.money');
-
     // Test valid value
-    $rule      = new MinValueRule(1000, $fieldComponent);
+    $rule      = new MinValueRule(1000, $moneyInput);
     $validator = Validator::make(
         ['money' => '15.00'],
         [
@@ -33,7 +26,7 @@ it('validates min value using MinValueRule', function (): void {
     expect($validator->passes())->toBeTrue();
 
     // Test too low value
-    $rule      = new MinValueRule(2000, $fieldComponent);
+    $rule      = new MinValueRule(2000, $moneyInput);
     $validator = Validator::make(
         ['money' => '15.00'],
         [
@@ -46,7 +39,7 @@ it('validates min value using MinValueRule', function (): void {
     expect($validator->errors()->first('money'))->toContain('least');
 
     // Test invalid(non-numeric) value
-    $rule      = new MinValueRule(1000, $fieldComponent);
+    $rule      = new MinValueRule(1000, $moneyInput);
     $validator = Validator::make(
         ['money' => 'abc'],
         [
@@ -65,15 +58,8 @@ it('validates max value using MaxValueRule', function (): void {
         ->currency('USD')
         ->locale('en_US');
 
-    // Initialize the component
-    $container = ComponentContainer::make(FormTestComponent::make())
-        ->statePath('data')
-        ->components([$moneyInput]);
-
-    $fieldComponent = $container->getComponent('data.money');
-
     // Test valid value
-    $rule      = new MaxValueRule(2000, $fieldComponent);
+    $rule      = new MaxValueRule(2000, $moneyInput);
     $validator = Validator::make(
         ['money' => '15.00'],
         [
@@ -85,7 +71,7 @@ it('validates max value using MaxValueRule', function (): void {
     expect($validator->passes())->toBeTrue();
 
     // Test too high value
-    $rule      = new MaxValueRule(1000, $fieldComponent);
+    $rule      = new MaxValueRule(1000, $moneyInput);
     $validator = Validator::make(
         ['money' => '15.00'],
         [
@@ -98,7 +84,7 @@ it('validates max value using MaxValueRule', function (): void {
     expect($validator->errors()->first('money'))->toContain('must be less than');
 
     // Test invalid(non-numeric) value
-    $rule      = new MaxValueRule(1000, $fieldComponent);
+    $rule      = new MaxValueRule(1000, $moneyInput);
     $validator = Validator::make(
         ['money' => 'abc'],
         [

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,7 @@ use Pelmered\FilamentMoneyField\Tests\Support\Components\FormTestComponent;
 use Pelmered\FilamentMoneyField\Tests\Support\Components\InfolistTestComponent;
 use Pelmered\FilamentMoneyField\Tests\Support\Components\TableTestComponent;
 use Pelmered\FilamentMoneyField\Tests\TestCase;
+use Filament\Schemas\Schema;
 
 pest()->project()->github('pelmered/filament-money-field');
 
@@ -64,7 +65,7 @@ function replaceNonBreakingSpaces(string $string): string
 function validationTester(Field $field, $value, ?callable $assertsCallback = null): true|array
 {
     try {
-        \Filament\Forms\ComponentContainer::make(FormTestComponent::make())
+        Schema::make(FormTestComponent::make())
             ->statePath('data')
             ->components([$field])
             ->fill([$field->getName() => $value])
@@ -86,7 +87,7 @@ function validationTester(Field $field, $value, ?callable $assertsCallback = nul
 /**
  * @throws Exception
  */
-function createTestComponent($type = 'form', $components = [], $fieldName = 'amount', $statePath = 'data'): Forms\ComponentContainer|Infolists\ComponentContainer
+function createTestComponent($type = 'form', $components = [], $fieldName = 'amount'): Schema
 {
     if (count($components) <= 0) {
         $components = match ($type) {
@@ -98,25 +99,24 @@ function createTestComponent($type = 'form', $components = [], $fieldName = 'amo
     }
 
     return (match ($type) {
-        'form'     => Forms\ComponentContainer::make(FormTestComponent::make()),
-        'infolist' => Infolists\ComponentContainer::make(InfolistTestComponent::make()),
+        'form'     => Schema::make(FormTestComponent::make()),
+        'infolist' => Schema::make(InfolistTestComponent::make()),
         // 'table' =>  \Filament\Tables\ComponentContainer::make(TableTestComponent::make()),
         default => throw new Exception('Unknown component type: '.$type),
     })
-        ->statePath($statePath)
         ->components($components);
 }
 
-function createFormTestComponent($components = [], $fill = [], $fieldName = 'amount', $statePath = 'data'): \Filament\Forms\ComponentContainer|\Filament\Infolists\ComponentContainer
+function createFormTestComponent($components = [], $fill = [], $fieldName = 'amount'): Schema
 {
-    $components = createTestComponent('form', $components, $fieldName, $statePath);
+    $components = createTestComponent('form', $components, $fieldName);
     $components->fill($fill);
 
     return $components;
 }
 
-function createInfolistTestComponent($components = [], string $fieldName = 'amount', string $statePath = 'data'): MoneyEntry
+function createInfolistTestComponent($components = [], string $fieldName = 'amount'): MoneyEntry
 {
-    return createTestComponent('infolist', $components, $fieldName, $statePath)
-        ->getComponent($statePath.'.'.$fieldName);
+    return createTestComponent('infolist', $components, $fieldName)
+        ->getComponent($fieldName);
 }

--- a/tests/Support/Components/TestComponent.php
+++ b/tests/Support/Components/TestComponent.php
@@ -4,7 +4,7 @@ namespace Pelmered\FilamentMoneyField\Tests\Support\Components;
 
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
-use Filament\Forms\Form;
+use Filament\Schemas\Schema;
 use Livewire\Component;
 use Pelmered\FilamentMoneyField\Forms\Components\MoneyInput;
 
@@ -21,7 +21,7 @@ class TestComponent extends Component implements HasForms
         return new static;
     }
 
-    public function form(Form $form): Form
+    public function form(Schema $form): Schema
     {
         return $form
             ->schema([


### PR DESCRIPTION
The codebase for v3 works mostly fine with v4. Just one change regarding the Action namespace change.

Tha tests had to be rewritten a bit because there no mode ComponentContainer in v4.

I manually tested the packages and everything seams to be fine from my end.