### PR TITLE
Fix error when changing currency in Filament V4

### DIFF
--- a/src/Forms/Components/MoneyInput.php
+++ b/src/Forms/Components/MoneyInput.php
@@ -45,7 +45,7 @@ class MoneyInput extends TextInput
                             ->required()
                             ->live(),
                     ])
-                    ->action(function (array $data, MoneyInput $component, Model $record, Form $form): void {
+                    ->action(function (array $data, MoneyInput $component, Model $record): void {
                         $money    = $record->{$component->name};
                         $currency = $data['currency'];
 


### PR DESCRIPTION
In V4 the Form class has been replaced by Scheme. As this variable is not used at all here, it can be removed. This should maintain V3 and V4 compatiblity.